### PR TITLE
Fix update job binding

### DIFF
--- a/src/components/EditJob.vue
+++ b/src/components/EditJob.vue
@@ -74,14 +74,6 @@ export default {
       this.skills = [];
       this.newSkill = ""
     },
-    /*// DEBUG
-    refreshForm: function() {
-      this.id = this.job.id || -1;
-      this.title = this.job.title || "";
-      this.description = this.job.description || "";
-      this.skills = JSON.parse(JSON.stringify(this.job.skills)) || []; // Create deep copy of job.skills
-      this.newSkill = "";
-    },*/
     addSkill: function() {
       this.skills.push(this.newSkill);
       this.newSkill = "";
@@ -99,15 +91,6 @@ export default {
       };
       this.$emit("job-saved", newJob);
       this.clearForm();
-      /*
-      if (newJob.id === -1) {
-        this.$emit("job-saved", newJob);
-        this.clearForm();
-      } else {
-        this.$emit("job-updated", newJob);
-        this.refreshForm();
-      }
-      */
     }
   }
 };

--- a/src/components/JobsIndex.vue
+++ b/src/components/JobsIndex.vue
@@ -27,7 +27,7 @@
           <ShowJob
             :job="job"
             @job-deleted="deleteJob(job)"
-            @job-updated="updateJob(job)"
+            @job-updated="updateJob($event)"
           />
         </li>
       </ul>
@@ -99,31 +99,21 @@ export default {
       this.jobs = this.jobs.filter(job => job !== deletedJob);
     },
     createJob(newJob) {
-      console.log("createJob called");
-
       // Create a new unique id and assign it to the new job
       newJob.id = Date.now();
-      /*
-      console.log("new Job: ");
-      console.log(newJob);
-      */
+
       // Add newJob to jobs
       this.jobs.push(newJob);
 
       // Reset form
       this.resetBlankJob();
     },
-    updateJob(newJob) {
-      console.log("updateJob called");
+    updateJob(jobWithEdits) {
       // Locate the original of the job that was edited
-      const index = this.jobs.findIndex(job => job.id === newJob.id);
-      console.log("index: " + index);
-      console.log("new Job: ");
-      console.log(newJob);
+      const index = this.jobs.findIndex(job => job.id === jobWithEdits.id);
+
       // Replace original job with edited version
-      this.jobs.splice(index, 1, newJob);
-      console.log("Jobs List:");
-      console.log(this.jobs);
+      this.jobs.splice(index, 1, jobWithEdits);
     }
   }
 };

--- a/src/components/ShowJob.vue
+++ b/src/components/ShowJob.vue
@@ -18,7 +18,7 @@
       <button type="button" @click="editJob()" key="edit-job">Edit Job</button>
     </template>
     <template v-else>
-      <EditJob :job="job" @job-saved="updateJob(job)" />
+      <EditJob :job="job" @job-saved="updateJob($event)" />
     </template>
   </div>
 </template>
@@ -46,13 +46,6 @@ export default {
     updateJob(newJob) {
       this.inEditMode = false; // Toggle back to show job
       this.$emit("job-updated", newJob);
-
-      /*******************************************
-      // Locate the original of the job that was edited
-      const index = this.jobs.findIndex(job => job.id === newJob.id);
-      // Replace original job with edited version
-      this.jobs[index] = newJob;
-      *******************************************/
     }
   }
 };


### PR DESCRIPTION
Remove form validation from EditJob.
Fix bug where changes from editing a job were not persisted.
Remove debug code & comments.
Refactor so that EditJob only emits "job-saved", ShowJob emits "job-updated" when returning from edit mode, and JobIndex handles the actual update logic.